### PR TITLE
Add Kafka serde generator

### DIFF
--- a/generator/app/controllers/Generators.scala
+++ b/generator/app/controllers/Generators.scala
@@ -170,13 +170,43 @@ object Generators {
       ),
       CodeGenTarget(
         metaData = Generator(
-          key = "kafka_serde",
-          name = "Kafka Serde",
+          key = "samza_serde_test",
+          name = "Samza Serde Test",
+          description = Some("Basic round trip test for Samza serdes. Requires Samza Serde."),
+          language = Some("Scala")
+        ),
+        status = lib.generator.Status.Beta,
+        codeGenerator = Some(scala.models.SamzaSerdeTest)
+      ),
+      CodeGenTarget(
+        metaData = Generator(
+          key = "kafka_0_9_serde",
+          name = "Kafka 0.9 Serde",
           description = Some("Kafka Serde adapters around Play JSON serdes. Requires Advanced Scala Models and Play JSON Standalone."),
           language = Some("Scala")
         ),
         status = lib.generator.Status.Beta,
-        codeGenerator = Some(scala.models.KafkaSerde)
+        codeGenerator = Some(scala.models.Kafka09Serde)
+      ),
+      CodeGenTarget(
+        metaData = Generator(
+          key = "kafka_0_9_serde_test",
+          name = "Kafka 0.9 Serde Test",
+          description = Some("Basic round trip test for Kafka 0.9 serdes. Requires Kafka 0.9 Serde."),
+          language = Some("Scala")
+        ),
+        status = lib.generator.Status.Beta,
+        codeGenerator = Some(scala.models.Kafka09SerdeTest)
+      ),
+      CodeGenTarget(
+        metaData = Generator(
+          key = "scalacheck_arbitrary",
+          name = "ScalaCheck Arbitrary",
+          description = Some("Arbitrary instances for case classes and enums for use with ScalaCheck. Requires Advanced Scala Models and static classes in generator-apidoc-libs."),
+          language = Some("Scala")
+        ),
+        status = lib.generator.Status.Beta,
+        codeGenerator = Some(scala.models.ScalaCheckArbitrary)
       )
   ).sortBy(_.metaData.key)
 }

--- a/generator/app/controllers/Generators.scala
+++ b/generator/app/controllers/Generators.scala
@@ -162,11 +162,21 @@ object Generators {
         metaData = Generator(
           key = "samza_serde",
           name = "Samza Serde",
-          description = Some("Samza Serde adaptors around Play JSON serdes. Requires Advanced Scala Models and Play JSON Standalone."),
+          description = Some("Samza Serde adapters around Play JSON serdes. Requires Advanced Scala Models and Play JSON Standalone."),
           language = Some("Scala")
         ),
         status = lib.generator.Status.Beta,
         codeGenerator = Some(scala.models.SamzaSerde)
+      ),
+      CodeGenTarget(
+        metaData = Generator(
+          key = "kafka_serde",
+          name = "Kafka Serde",
+          description = Some("Kafka Serde adapters around Play JSON serdes. Requires Advanced Scala Models and Play JSON Standalone."),
+          language = Some("Scala")
+        ),
+        status = lib.generator.Status.Beta,
+        codeGenerator = Some(scala.models.KafkaSerde)
       )
   ).sortBy(_.metaData.key)
 }

--- a/scala-generator/src/main/scala/models/Kafka09Serde.scala
+++ b/scala-generator/src/main/scala/models/Kafka09Serde.scala
@@ -11,8 +11,8 @@ import scala.generator.ScalaService
 import generator.ServiceFileNames
 
 // Copied from Play2Models
-object KafkaSerde extends KafkaSerde
-trait KafkaSerde extends CodeGenerator {
+object Kafka09Serde extends Kafka09Serde
+trait Kafka09Serde extends CodeGenerator {
 
   override def invoke(form: InvocationForm): Either[Seq[String], Seq[File]] = {
     ScalaCaseClasses.modelsWithTooManyFieldsErrors(form.service) match {

--- a/scala-generator/src/main/scala/models/KafkaSerde.scala
+++ b/scala-generator/src/main/scala/models/KafkaSerde.scala
@@ -1,0 +1,87 @@
+package scala.models
+
+import com.bryzek.apidoc.generator.v0.models.{File, InvocationForm}
+import lib.Text._
+import lib.generator.CodeGenerator
+import scala.generator.ScalaCaseClasses
+import scala.generator.ScalaDatatype
+import scala.generator.ScalaField
+import scala.generator.ScalaPrimitive
+import scala.generator.ScalaService
+import generator.ServiceFileNames
+
+// Copied from Play2Models
+object KafkaSerde extends KafkaSerde
+trait KafkaSerde extends CodeGenerator {
+
+  override def invoke(form: InvocationForm): Either[Seq[String], Seq[File]] = {
+    ScalaCaseClasses.modelsWithTooManyFieldsErrors(form.service) match {
+      case Nil    => Right(generateCode(form = form, addBindables = true, addHeader = true))
+      case errors => Left(errors)
+    }
+  }
+
+  def generateCode(form: InvocationForm, addBindables: Boolean, addHeader: Boolean): Seq[File] = {
+    val ssd = ScalaService(form.service)
+
+    val header = addHeader match {
+      case false => ""
+      case true => ApidocComments(form.service.version, form.userAgent).toJavaString() + "\n"
+    }
+
+    def generateSerdeClasses(simpleName: String, fullName: String): String = {
+      s"""class ${simpleName}Serializer extends Serializer[${fullName}] {
+         |  override def configure(configs: JMap[String, _], isKey: Boolean): Unit = {}
+         |  override def close(): Unit = {}
+         |  override def serialize(topic: String, obj: ${fullName}): Array[Byte] = {
+         |    Json.toJson(obj).toString.getBytes(StandardCharsets.UTF_8)
+         |  }
+         |}
+         |class ${simpleName}Deserializer extends Deserializer[${fullName}] {
+         |  override def configure(configs: JMap[String, _], isKey: Boolean): Unit = {}
+         |  override def close(): Unit = {}
+         |  override def deserialize(topic: String, bytes: Array[Byte]): ${fullName} = {
+         |    Try(Json.parse(bytes).as[${fullName}]) match {
+         |      case Success(obj) ⇒ obj
+         |      case Failure(ex) ⇒ throw new SerializationException("Failed to parse ${simpleName}", ex)
+         |    }
+         |  }
+         |}
+      """.stripMargin
+    }
+
+    val models = ssd.models map { model ⇒
+      generateSerdeClasses(model.name, model.qualifiedName)
+    }
+
+    val source = s"""$header
+package ${ssd.namespaces.models} {
+  package object serde {
+    import org.apache.kafka.common.serialization.Serializer
+    import org.apache.kafka.common.serialization.Deserializer
+    import org.apache.kafka.common.errors.SerializationException
+    import play.api.libs.json.Json
+    import ${ssd.namespaces.models}.json._
+    import java.nio.charset.StandardCharsets
+    import java.util.{Map ⇒ JMap}
+    import scala.util.Failure
+    import scala.util.Success
+    import scala.util.Try
+
+${models.mkString("\n\n").indent(4)}
+  }
+}
+"""
+    Seq(
+      ServiceFileNames.toFile(
+        form.service.namespace,
+        form.service.organization.key,
+        form.service.application.key,
+        form.service.version,
+        "Serde",
+        source,
+        Some("Scala")
+      )
+    )
+  }
+}

--- a/scala-generator/src/main/scala/models/SamzaSerdeTest.scala
+++ b/scala-generator/src/main/scala/models/SamzaSerdeTest.scala
@@ -1,0 +1,72 @@
+package scala.models
+
+import com.bryzek.apidoc.generator.v0.models.{File, InvocationForm}
+import lib.Text._
+import lib.generator.CodeGenerator
+import scala.generator.ScalaCaseClasses
+import scala.generator.ScalaDatatype
+import scala.generator.ScalaField
+import scala.generator.ScalaPrimitive
+import scala.generator.ScalaService
+import generator.ServiceFileNames
+
+object SamzaSerdeTest extends SamzaSerdeTest
+trait SamzaSerdeTest extends CodeGenerator {
+
+  override def invoke(form: InvocationForm): Either[Seq[String], Seq[File]] = {
+    ScalaCaseClasses.modelsWithTooManyFieldsErrors(form.service) match {
+      case Nil    => Right(generateCode(form = form, addBindables = true, addHeader = true))
+      case errors => Left(errors)
+    }
+  }
+
+  def generateCode(form: InvocationForm, addBindables: Boolean, addHeader: Boolean): Seq[File] = {
+    val ssd = ScalaService(form.service)
+
+    val header = addHeader match {
+      case false => ""
+      case true => ApidocComments(form.service.version, form.userAgent).toJavaString() + "\n"
+    }
+
+    def generateTest(simpleName: String, fullName: String): String = {
+      s"""class ${simpleName}SerdeTest extends WordSpec with Matchers with PropertyChecks {
+         |  import arbitrary._
+         |
+         |  "${simpleName} serde" should {
+         |    "round trip" in {
+         |      val _serde = new serde.${simpleName}Serde()
+         |      forAll { obj: ${fullName} =>
+         |        _serde.fromBytes(_serde.toBytes(obj)) shouldBe obj
+         |      }
+         |    }
+         |  }
+         |}
+      """.stripMargin
+    }
+
+    val models = ssd.models map { model ⇒
+      generateTest(model.name, model.qualifiedName)
+    }
+
+    val source = s"""$header
+package ${ssd.namespaces.models} {
+  import org.scalatest.Matchers
+  import org.scalatest.WordSpec
+  import org.scalatest.prop.PropertyChecks
+
+${models.mkString("\n\n").indent(2)}
+}
+"""
+    Seq(
+      ServiceFileNames.toFile(
+        form.service.namespace,
+        form.service.organization.key,
+        form.service.application.key,
+        form.service.version,
+        "SerdeTest",
+        source,
+        Some("Scala")
+      )
+    )
+  }
+}

--- a/scala-generator/src/main/scala/models/ScalaCheckArbitrary.scala
+++ b/scala-generator/src/main/scala/models/ScalaCheckArbitrary.scala
@@ -1,0 +1,88 @@
+package scala.models
+
+import com.bryzek.apidoc.generator.v0.models.{File, InvocationForm}
+import lib.Text._
+import lib.generator.CodeGenerator
+import scala.generator._
+import generator.ServiceFileNames
+
+object ScalaCheckArbitrary extends ScalaCheckArbitrary
+trait ScalaCheckArbitrary extends CodeGenerator {
+
+  override def invoke(form: InvocationForm): Either[Seq[String], Seq[File]] = {
+    ScalaCaseClasses.modelsWithTooManyFieldsErrors(form.service) match {
+      case Nil    => Right(generateCode(form = form, addBindables = true, addHeader = true))
+      case errors => Left(errors)
+    }
+  }
+
+  def generateCode(form: InvocationForm, addBindables: Boolean, addHeader: Boolean): Seq[File] = {
+    val ssd = ScalaService(form.service)
+
+    val header = addHeader match {
+      case false => ""
+      case true => ApidocComments(form.service.version, form.userAgent).toJavaString() + "\n"
+    }
+
+    def getFieldName(field: ScalaField): String =
+      ScalaUtil.quoteNameIfKeyword(snakeToCamelCase(field.name))
+
+    def getFieldArbitrary(field: ScalaField): String = {
+      val name = getFieldName(field)
+      val tpe =
+        CaseClassUtil.getScalaProps(field.field) match {
+          case Some(props) ⇒
+            val rootedType = "_root_." + props.`class`.get
+            if (field.required)
+              rootedType
+            else
+              s"_root_.scala.Option[${rootedType}]"
+          case None ⇒
+            field.datatype.name
+        }
+      s"${name} <- arbitrary[${tpe}]"
+    }
+
+    def generateCaseClass(model: ScalaModel): String =
+      s"""implicit val arb${model.name}: Arbitrary[${model.qualifiedName}] = Arbitrary {
+         |  for {
+         |${model.fields.map(getFieldArbitrary).mkString("\n").indent(4)}
+         |  } yield ${model.qualifiedName}.apply(${model.fields.map(getFieldName).mkString(", ")})
+         |}
+         |""".stripMargin
+
+    def generateEnum(enum: ScalaEnum): String =
+      s"""implicit val arb${enum.name}: Arbitrary[${enum.qualifiedName}] =
+         |  Arbitrary(Gen.oneOf(${enum.qualifiedName}.all))
+         |""".stripMargin
+
+    val models = ssd.models.map(generateCaseClass)
+    val enums = ssd.enums.map(generateEnum)
+
+    val source = s"""$header
+package ${ssd.namespaces.models} {
+  package object arbitrary {
+    import org.scalacheck.Arbitrary
+    import org.scalacheck.Arbitrary.arbitrary
+    import org.scalacheck.Gen
+    import movio.cinema.test.StandardArbitraries._
+
+${enums.mkString("\n\n").indent(4)}
+
+${models.mkString("\n\n").indent(4)}
+  }
+}
+"""
+    Seq(
+      ServiceFileNames.toFile(
+        form.service.namespace,
+        form.service.organization.key,
+        form.service.application.key,
+        form.service.version,
+        "Arbitrary",
+        source,
+        Some("Scala")
+      )
+    )
+  }
+}


### PR DESCRIPTION
Adds generators for Kafka's `Serializer` and `Deserializer` interfaces, which can be used with the producer and consumer config's `key.serializer`, `key.deserializer`, `value.serializer` and `value.deserializer` configs.

This is a simple wrapper around the Play JSON serdes.

Tested against `"org.apache.kafka" % "kafka-clients" % "0.9.0.1"`.
